### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled command line

### DIFF
--- a/analytics/sbom_service.py
+++ b/analytics/sbom_service.py
@@ -21,6 +21,21 @@ logger = logging.getLogger(__name__)
 class SBOMService:
     """Service for generating and processing SBOMs"""
     
+    def _validate_repo_path(self, repo_path: str):
+        """
+        Validate that the repo_path is an absolute path within the system temp directory.
+        Raises an exception if the path is invalid.
+        """
+        temp_dir = tempfile.gettempdir()
+        abs_repo_path = os.path.abspath(repo_path)
+        abs_temp_dir = os.path.abspath(temp_dir)
+        if not abs_repo_path.startswith(abs_temp_dir + os.sep):
+            logger.error(f"Invalid repo_path: {repo_path} is not within temp directory {temp_dir}")
+            raise ValueError("Invalid repository path for SBOM generation.")
+        if not os.path.isdir(abs_repo_path):
+            logger.error(f"Invalid repo_path: {repo_path} is not a directory")
+            raise ValueError("Repository path for SBOM generation is not a directory.")
+    
     def __init__(self, repository_full_name: str, user_id: int):
         self.repository_full_name = repository_full_name
         self.user_id = user_id
@@ -36,6 +51,7 @@ class SBOMService:
         Returns:
             Dictionary with SBOM data and metadata
         """
+        self._validate_repo_path(repo_path)
         logger.info(f"Generating SBOM for {self.repository_full_name} at {repo_path}")
         
         # Prepare environment variables


### PR DESCRIPTION
Potential fix for [https://github.com/assiadialeb/gitpulse/security/code-scanning/2](https://github.com/assiadialeb/gitpulse/security/code-scanning/2)

To fix this issue, we should ensure that the `repo_path` argument passed to the subprocess is safe and cannot be manipulated to perform command injection or other malicious actions. The best way to do this is to validate that `repo_path` is an absolute path, points to a directory within a known safe temporary directory, and does not contain any suspicious characters or path traversal sequences. This can be done by checking that `repo_path` is a subdirectory of the expected temporary directory (e.g., `/tmp` or the value returned by `tempfile.gettempdir()`), and by rejecting any path that does not meet these criteria.

The validation should be performed at the start of the `generate_sbom` method in `analytics/sbom_service.py`, before constructing the command. If the path is invalid, an exception should be raised and the operation aborted.

**Required changes:**
- Add a helper method (e.g., `_validate_repo_path`) to `SBOMService` that checks if `repo_path` is an absolute path, is within the system temp directory, and does not contain suspicious elements.
- Call this method at the start of `generate_sbom`.
- If the path is invalid, log an error and raise an exception.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
